### PR TITLE
Explicitly install leiningen on ubuntu-latest

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Setup Java
@@ -13,6 +13,10 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
         architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Cache m2 repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,11 @@ jobs:
       id : master_base_sha
       if : github.ref  == 'refs/heads/master'
       run: echo  "::set-output name=base_sha::${{ github.event.before }}"
-    - uses: xcoo/clj-lint-action@v1.1.10
+    - uses: xcoo/clj-lint-action@v1.1.12
       with:
         linters: "[\"clj-kondo\" \"kibit\" \"eastwood\"]"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         runner: ":leiningen"
         base_sha: ${{ github.event.pull_request.base.sha||steps.master_base_sha.outputs.base_sha }}
         eastwood_linters: "[:all]"
+        linter_options: "{}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
         architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
related: https://github.com/chrovis/cljam/pull/331

The OS version of the runner instances provided by `ubuntu-latest` in GitHub Actions [will be upgraded from 22.04 to 24.04 between 2024/12/05 and 2025/01/17](https://github.com/actions/runner-images/issues/10636).
Unlike 22.04, Leiningen is not pre-installed on 24.04. Therefore, I have modified the workflow to explicitly install it using [DeLaGuardo/setup-clojure](https://github.com/DeLaGuardo/setup-clojure).

I have also upgraded [`clj-lint-action` to v1.1.12](https://github.com/xcoo/clj-lint-action/compare/v1.1.10...v1.1.12).